### PR TITLE
Replace gradle/wrapper-validation-action with gradle/actions/wrapper-validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
 
       # Validate wrapper
       - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v3.5.0
+        uses: gradle/actions/wrapper-validation@v3.5.0
 
       # Setup Java 11 environment for the next steps
       - name: Setup Java


### PR DESCRIPTION
> As of v3 this action has been deprecated by gradle/actions/wrapper-validation.
Any workflow that uses gradle/wrapper-validation-action@v3 will transparently delegate to gradle/actions/wrapper-validation@v3. 

https://github.com/gradle/wrapper-validation-action/releases/tag/v3.5.0