### PR TITLE
fix: Handle directory paths explicitly when loading Vault token/config/certificate files

### DIFF
--- a/src/main/java/com/premiumminds/vault/client/DefaultVaultTokenLoader.java
+++ b/src/main/java/com/premiumminds/vault/client/DefaultVaultTokenLoader.java
@@ -34,12 +34,14 @@ public class DefaultVaultTokenLoader implements VaultTokenLoader {
     public String get() throws Exception {
         if (tokenFile.isPresent() && !tokenFile.toString().isBlank()) {
             if (tokenFile.get().toFile().exists()){
+                assertRegularFile(tokenFile.get(), "Vault token file");
                 return Files.readString(tokenFile.get());
             }
         }
 
         final var vaultConfigFile = getConfigFile();
         if (vaultConfigFile.toFile().exists()){
+            assertRegularFile(vaultConfigFile, "Vault config file");
             final String token = getTokenFromVaultTokenHelper(vaultConfigFile, vaultAddress);
             if (token != null){
                 return token;
@@ -47,6 +49,7 @@ public class DefaultVaultTokenLoader implements VaultTokenLoader {
         }
         final var defaultTokenFilePath = Paths.get(System.getProperty("user.home"), DEFAULT_VAULT_TOKEN_FILE);
         if (defaultTokenFilePath.toFile().exists()){
+            assertRegularFile(defaultTokenFilePath, "Vault token file");
             return Files.readString(defaultTokenFilePath);
         }
 
@@ -62,6 +65,12 @@ public class DefaultVaultTokenLoader implements VaultTokenLoader {
         }
 
         return vaultConfigPath;
+    }
+
+    private static void assertRegularFile(Path path, String description) {
+        if (!Files.isRegularFile(path)) {
+            throw new IllegalArgumentException(description + " path is not a file: " + path);
+        }
     }
 
     private String getTokenFromVaultTokenHelper(Path configFile, String vaultAddress)

--- a/src/main/java/com/premiumminds/vault/client/VaultClient.java
+++ b/src/main/java/com/premiumminds/vault/client/VaultClient.java
@@ -13,6 +13,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyStore;
 import java.security.SecureRandom;
@@ -189,6 +190,9 @@ public class VaultClient {
     }
 
     private SSLContext getSSLContext(Path certificate) throws Exception {
+        if (!Files.isRegularFile(certificate)) {
+            throw new IllegalArgumentException("Vault certificate path is not a file: " + certificate);
+        }
 
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
 

--- a/src/main/java/com/premiumminds/vault/client/VaultClient.java
+++ b/src/main/java/com/premiumminds/vault/client/VaultClient.java
@@ -189,10 +189,17 @@ public class VaultClient {
         return builder.build();
     }
 
-    private SSLContext getSSLContext(Path certificate) throws Exception {
+    static void validateCertificatePath(Path certificate) {
+        if (!Files.exists(certificate)) {
+            throw new IllegalArgumentException("Vault certificate file does not exist: " + certificate);
+        }
         if (!Files.isRegularFile(certificate)) {
             throw new IllegalArgumentException("Vault certificate path is not a file: " + certificate);
         }
+    }
+
+    private SSLContext getSSLContext(Path certificate) throws Exception {
+        validateCertificatePath(certificate);
 
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
 

--- a/src/test/java/com/premiumminds/vault/client/VaultClientTest.java
+++ b/src/test/java/com/premiumminds/vault/client/VaultClientTest.java
@@ -8,13 +8,16 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -22,6 +25,34 @@ class VaultClientTest {
 
     @TempDir
     Path tempDir;
+
+    @Test
+    void tokenFileDirectoryReturnsExplicitError() throws Exception {
+        final var tokenDir = tempDir.resolve("token-dir");
+        Files.createDirectory(tokenDir);
+        final var loader = new DefaultVaultTokenLoader(java.util.Optional.of(tokenDir), "http://localhost:8200");
+
+        final var exception = assertThrows(IllegalArgumentException.class, loader::get);
+        assertEquals("Vault token file path is not a file: " + tokenDir, exception.getMessage());
+    }
+
+    @Test
+    void vaultConfigDirectoryReturnsExplicitError() throws Exception {
+        final var originalUserHome = System.getProperty("user.home");
+        final var vaultConfigDir = tempDir.resolve(".vault");
+        Files.createDirectory(vaultConfigDir);
+
+        try {
+            System.setProperty("user.home", tempDir.toString());
+
+            final var loader = new DefaultVaultTokenLoader(java.util.Optional.empty(), "http://localhost:8200");
+            final var exception = assertThrows(IllegalArgumentException.class, loader::get);
+
+            assertEquals("Vault config file path is not a file: " + vaultConfigDir, exception.getMessage());
+        } finally {
+            System.setProperty("user.home", originalUserHome);
+        }
+    }
 
     @Test
     void dynamicCredentials() throws Exception {

--- a/src/test/java/com/premiumminds/vault/client/VaultClientTest.java
+++ b/src/test/java/com/premiumminds/vault/client/VaultClientTest.java
@@ -55,6 +55,25 @@ class VaultClientTest {
     }
 
     @Test
+    void missingCertificateReturnsExplicitError() {
+        final var missingCertificate = tempDir.resolve("missing-ca.pem");
+
+        final var exception = assertThrows(IllegalArgumentException.class,
+                () -> VaultClient.validateCertificatePath(missingCertificate));
+        assertEquals("Vault certificate file does not exist: " + missingCertificate, exception.getMessage());
+    }
+
+    @Test
+    void certificateDirectoryReturnsExplicitError() throws Exception {
+        final var certificateDir = tempDir.resolve("certificate-dir");
+        Files.createDirectory(certificateDir);
+
+        final var exception = assertThrows(IllegalArgumentException.class,
+                () -> VaultClient.validateCertificatePath(certificateDir));
+        assertEquals("Vault certificate path is not a file: " + certificateDir, exception.getMessage());
+    }
+
+    @Test
     void dynamicCredentials() throws Exception {
 
         final var network = Network.newNetwork();


### PR DESCRIPTION
This change improves error handling for local Vault-related file paths used by the plugin.
Previously, if the configured token file, the resolved Vault config path, or the SSL certificate path existed but was a directory instead of a regular file, the plugin would surface a generic error such as `Problem connecting to Vault: Is a directory`. That message was misleading because the failure happened before any Vault API request was made.
This PR adds explicit validation for those paths and fails with a clearer message indicating which path is invalid and that a file was expected. It also adds targeted tests covering the token-file and default Vault-config directory cases.
This should make it much easier to diagnose local configuration issues such as:
- `Token File` pointing to a directory
- `VAULT_CONFIG_PATH` pointing to a directory
- `~/.vault` existing as a directory instead of a JSON config file